### PR TITLE
Add Timezone America/Asuncion

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -57,6 +57,7 @@ module ActiveSupport
       "Caracas"                      => "America/Caracas",
       "La Paz"                       => "America/La_Paz",
       "Santiago"                     => "America/Santiago",
+      "Asuncion"                     => "America/Asuncion",
       "Newfoundland"                 => "America/St_Johns",
       "Brasilia"                     => "America/Sao_Paulo",
       "Buenos Aires"                 => "America/Argentina/Buenos_Aires",


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because ActiveSupport does not support America/Asuncion as an IANA timezone. Since this is a valid identifier, It should be possible to be selected.

FYI, Asuncion stopped DST last year. That's why we need to treat it in a special way.

### Detail

This Pull Request changes ActiveSupport::TimeZone::MAPPING to include America/Asuncion.

### Additional information

https://www.timeanddate.com/time/zone/paraguay/asuncion

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature. -> Does not apply
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
